### PR TITLE
Policy for teachers promoting other teachers

### DIFF
--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -15,9 +15,11 @@ class UserPolicy < ApplicationPolicy
   def update?
     user.teacher? || user == record
   end
+
   def impersonate?
     user.admin?
   end
+
   def comment?
     user.teacher?
   end

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -171,6 +171,8 @@
                 <%= button_tag type: 'button', class: 'btn btn-default do-bulk-edit', data: { action: 'join_profiles', id: nil} do %>
                   Unir perfiles
                 <% end %>
+              <% end %>
+              <% if policy(User).promote? %>
                 <%= button_tag type: 'button', class: 'btn btn-default do-bulk-edit', data: { action: 'promote', id: nil} do %>
                   Nombrar docentes
                 <% end %>


### PR DESCRIPTION
Ref: [Trello](https://trello.com/c/bZNmKeXt/271-nombrar-docente-deberia-ser-permitido-para-otros-docentes)