### PR TITLE
PeerReview::Challenge shortcuts for teachers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 browser:
-	google-chrome --new-window https://trello.com/b/ARo5MV67/the-loom http://localhost:3000
+	google-chrome --new-window https://trello.com/b/ARo5MV67/the-loom http://localhost:3000 https://github.com/the-loom/dashboard
 
 init:
 	git config core.hooksPath .githooks

--- a/app/controllers/peer_review/reviews_controller.rb
+++ b/app/controllers/peer_review/reviews_controller.rb
@@ -34,8 +34,12 @@ module PeerReview
 
       if @review.valid?
         @review.save
-        redirect_to peer_review_challenge_path(@challenge)
         flash[:info] = "Se guardó correctamente la revisión"
+        if current_user.teacher?
+          redirect_to overview_peer_review_challenge_path(@challenge)
+        else
+          redirect_to peer_review_challenge_path(@challenge)
+        end
       else
         render action: :new
       end

--- a/app/controllers/peer_review/solutions_controller.rb
+++ b/app/controllers/peer_review/solutions_controller.rb
@@ -53,14 +53,25 @@ module PeerReview
 
     def unpublish
       @challenge = PeerReview::Challenge.find(params[:challenge_id])
-      @solution = PeerReview::Solution.find_by(challenge: @challenge, author: current_user)
-      if @solution.author == current_user && @solution.unpublishable?
+
+      @solution = PeerReview::Solution.find(params[:id])
+      if current_user.teacher?
+      else
+        @solution = PeerReview::Solution.find_by(challenge: @challenge, author: current_user)
+      end
+
+      if policy(@solution).unpublish?
         @solution.unpublish!
         flash[:info] = "Se despublicó tu solución. Podés volver a trabajar en ella"
       else
         flash[:alert] = "Esta vez no ha podido despublicarse tu solución"
       end
-      redirect_to peer_review_challenge_path(@challenge)
+
+      if current_user.teacher?
+        redirect_to overview_peer_review_challenge_path(@challenge)
+      else
+        redirect_to peer_review_challenge_path(@challenge)
+      end
     end
 
     private

--- a/app/policies/peer_review/solution_policy.rb
+++ b/app/policies/peer_review/solution_policy.rb
@@ -5,4 +5,7 @@ class PeerReview::SolutionPolicy < ApplicationPolicy
   def solve?
     (user.teacher? || user.student?) && record.draft?
   end
+  def unpublish?
+    (record.author == user && record.unpublishable?) || user.teacher? && record.status.to_sym == :final
+  end
 end

--- a/app/views/peer_review/challenges/overview.html.erb
+++ b/app/views/peer_review/challenges/overview.html.erb
@@ -49,9 +49,10 @@
       <td>
         <%= stats.solver.full_name %> <br/>
         <%= link_to "Ver solución", peer_review_challenge_solution_path(@challenge, stats.solution) %>
-        <% unless stats.solution.review_by(current_user).present? || stats.solution.draft? %>
+        <% my_review = stats.solution.review_by(current_user) %>
+        <% unless my_review.present? && my_review.status.to_sym == :final || stats.solution.draft? %>
           •
-          <%= link_to "Revisar", review_peer_review_challenge_solution_path(@challenge, stats.solution) %>
+          <%= link_to (my_review.present? ? 'Continuar revisión' : 'Revisar'), review_peer_review_challenge_solution_path(@challenge, stats.solution) %>
         <% end %>
       </td>
       <td>

--- a/app/views/peer_review/challenges/show.html.erb
+++ b/app/views/peer_review/challenges/show.html.erb
@@ -25,7 +25,7 @@
     <%= link_to 'Resolver', new_peer_review_challenge_solution_path(@challenge.id), class: 'btn btn-large btn-primary', disabled: !@challenge.solvable_by?(current_user) %>
     <%= link_to 'Revisar alguna solución', new_peer_review_challenge_review_path(@challenge.id), class: 'btn btn-large btn-primary', disabled: !@challenge.reviewable_by?(current_user) %>
 
-    <% if @solution && @solution.unpublishable? %>
+    <% if @solution && policy(@solution).unpublish? %>
       <%= link_to 'Despublicar solución', unpublish_peer_review_challenge_solution_path(@challenge.id, @solution), method: :post, class: 'btn btn-large btn-warning', disabled: !@challenge.reviewable_by?(current_user) %>
     <% end %>
 

--- a/app/views/peer_review/solutions/show.html.erb
+++ b/app/views/peer_review/solutions/show.html.erb
@@ -30,8 +30,31 @@
   </div>
 <% end %>
 
-<% unless @solution.review_by(current_user).present? %>
-  <%= link_to "Agregar mi revisión", review_peer_review_challenge_solution_path(@challenge, @solution), class: 'btn btn-primary' %>
+<% if @solution.final? %>
+  <% my_review = @solution.review_by(current_user) %>
+  <% if my_review.present? && my_review.draft? %>
+    <%= link_to "Continuar mi revisión", review_peer_review_challenge_solution_path(@challenge, @solution), class: 'btn btn-primary' %>
+  <% elsif !my_review.present? %>
+    <%= link_to "Agregar mi revisión", review_peer_review_challenge_solution_path(@challenge, @solution), class: 'btn btn-primary' %>
+  <% end %>
+<% end %>
+
+<br><br>
+
+<% if policy(@solution).unpublish? %>
+  <div class="alert alert-danger">
+    <ul>
+      <li>Sólo deberías despublicar una solución si es extremadamente necesario</li>
+      <li>Esta acción ocasionará que el estudiante
+        vuelva a publicarla luego de hacer las ediciones correspondientes
+      </li>
+      <li>Tené en cuenta que las revisiones que haya recibido
+        quedarán obsoletas.
+      </li>
+    </ul>
+    <br>
+    <%= link_to 'Despublicar solución del estudiante', unpublish_peer_review_challenge_solution_path(@challenge.id, @solution), method: :post, class: 'btn btn-large btn-danger' %>
+  </div>
 <% end %>
 
 <h2>Revisiones Recibidas</h2>


### PR DESCRIPTION
This PR is intended to allow teachers to:
1. Continue a pending review from overview, and from solution details
2. Go back to overview every time they publish a review
3. Unpublish some student's solution if needed

Bonus: Adds github repo to `make browser` task :smiley: 