### PR TITLE
It now avoids error 500 when not finding a challenge (mostly because …

### DIFF
--- a/app/controllers/peer_review/challenges_controller.rb
+++ b/app/controllers/peer_review/challenges_controller.rb
@@ -70,7 +70,13 @@ module PeerReview
     end
 
     def show
-      @challenge = PeerReview::Challenge.find(params[:id])
+      @challenge = PeerReview::Challenge.find_by(id: params[:id])
+
+      unless @challenge
+        flash[:alert] = "No pudimos encontrar el desafío que buscás... ¿es de este curso?"
+        redirect_to(peer_review_challenges_path) && return
+      end
+
       authorize @challenge, :show?
       @solution = ::SolutionFinder.new(@challenge, current_user).find_solution
     end


### PR DESCRIPTION
…of wrong course)

Ref: [Trello](https://trello.com/c/1B92vVu3/307-quick-fix-si-entraste-a-un-challenge-de-otro-curso-que-no-te-tire-500)