### PR TITLE
Changes misleading totals in challenge overview

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ tests:
 	docker-compose run app ./bin/rake
 
 use_production_db:
+	$(MAKE) stop
 	heroku pg:backups capture --app the-loom
 	curl -o tmp/latest.dump `heroku pg:backups public-url --app the-loom`
 	docker-compose run app bundle exec rake db:drop db:create

--- a/app/presenters/peer_review/overview_presenter.rb
+++ b/app/presenters/peer_review/overview_presenter.rb
@@ -2,11 +2,13 @@ class PeerReview::OverviewPresenter
   attr_reader :registers
 
   def initialize(challenge)
+    solutions = challenge.solutions.final.size
+    reviews = challenge.reviews.final.size
     @registers = [
-        OpenStruct.new(name: "Soluciones", value: challenge.solutions.size),
-        OpenStruct.new(name: "Revisiones", value: challenge.reviews.size),
-        OpenStruct.new(name: "Revisiones por ejercicio", value: challenge.solutions.size > 0 ? (challenge.reviews.size.to_f / challenge.solutions.size).round(2) : 0),
-        OpenStruct.new(name: "Revisiones potenciales", value: challenge.solutions.size * (challenge.solutions.size - 1))
+        OpenStruct.new(name: "Soluciones finalizadas", value: solutions),
+        OpenStruct.new(name: "Revisiones finalizadas", value: reviews),
+        OpenStruct.new(name: "Revisiones por ejercicio", value: solutions > 0 ? (reviews.to_f / solutions).round(2) : 0),
+        OpenStruct.new(name: "Revisiones potenciales", value: solutions * (solutions - 1))
     ]
   end
 end


### PR DESCRIPTION
Ref: [Trello](https://trello.com/c/E4dASgqR/328-el-total-de-soluciones-no-deberia-contar-los-drafts)

Los totales estaban contando soluciones y revisiones en borrador, por lo que los totales no eran correctos. Se aprovecha la ocasión para guardar los valores de cálculo en variables intermedias, y así ahorrar tiempo de procesamiento y cache.