### PR TITLE
Purges due challenges

### DIFF
--- a/app/controllers/peer_review/challenges_controller.rb
+++ b/app/controllers/peer_review/challenges_controller.rb
@@ -149,9 +149,7 @@ module PeerReview
       authorize PeerReview::Challenge, :purge?
       challenge = PeerReview::Challenge.find(params[:id])
 
-      # move to challenge?
-      challenge.reviews.where(status: :draft).delete_all
-      challenge.solutions.where(status: :draft).delete_all
+      challenge.purge!
 
       flash[:info] = "Se purgó correctamente el desafío"
       redirect_to peer_review_challenges_path

--- a/app/models/peer_review/challenge.rb
+++ b/app/models/peer_review/challenge.rb
@@ -72,7 +72,17 @@ class PeerReview::Challenge < ApplicationRecord
 
   def due?
     return false unless due_date
-    Time.zone.now > self.due_date + 1.day
+    Time.zone.now > self.due_date.beginning_of_day + 1.day
+  end
+
+  def needs_purge?
+    self.reviews.where(status: :draft).count > 0 ||
+        self.solutions.where(status: :draft).count > 0
+  end
+
+  def purge!
+    self.reviews.where(status: :draft).delete_all
+    self.solutions.where(status: :draft).delete_all
   end
 
   def disable!

--- a/lib/tasks/disable_challenges.rake
+++ b/lib/tasks/disable_challenges.rake
@@ -7,7 +7,7 @@ namespace :challenges do
       puts "Disabling Challenges for Course #{course.name}"
 
       PeerReview::Challenge.all.each do |challenge|
-        if challenge.due?
+        if challenge.due? && challenge.enabled?
           challenge.disable!
           puts "-> #{challenge.title} has been disabled"
         end

--- a/lib/tasks/purge_challenges.rake
+++ b/lib/tasks/purge_challenges.rake
@@ -1,0 +1,21 @@
+namespace :challenges do
+  desc "Purges due PeerReview::Challenges"
+  task purge: :environment do
+    Course.enabled.each do |course|
+      Course.current = course
+      next unless course.on?(:peer_review_challenges)
+      puts "Purging Challenges for Course #{course.name}"
+
+      PeerReview::Challenge.all.each do |challenge|
+        if challenge.due? && challenge.needs_purge?
+          challenge.purge!
+          puts "-> #{challenge.title} has been purged"
+        end
+      end
+
+      puts "Finished purging for Course #{course.name}"
+    end
+
+    puts "Purging completed"
+  end
+end


### PR DESCRIPTION
Ref: [Trello](https://trello.com/c/SGVJda5G/330-tarea-para-purgar-una-semana-dps-de-vencido-el-ejercicio-y-solo-si-tiene-algo-que-purgar)

Necesitamos purgar los ejercicios, para evitar que se acumulen soluciones en borrador que no hayan sido publicadas. Esto sucederá una vez vencidos los ejercicios.
Quizás el día de mañana se requiera que en lugar de borrarse, se marquen como borrados. Sin embargo, por ahora tenemos que pensar en la capacidad de la base de datos como prioridad.