### PR TITLE
There should be no progress if there is no solution

### DIFF
--- a/app/models/peer_review/challenge.rb
+++ b/app/models/peer_review/challenge.rb
@@ -97,16 +97,16 @@ class PeerReview::Challenge < ApplicationRecord
     progress = 0.0
 
     # solved?
-    progress += 1 if already_solved_by?(user) || (team_challenge? && already_solved_by_team?(user.current_membership.team))
+    progress += 1.0 if already_solved_by?(user) || (team_challenge? && already_solved_by_team?(user.current_membership.team))
 
-    return [progress / 1, 1.0].min if teacher_reviews_only?
+    return [progress / 1.0, 1.0].min if teacher_reviews_only? || progress == 0.0
     # reviewed?
     progress += solutions.includes(:reviews).includes(reviews: :reviewer)
                     .where(peer_review_reviews: { status: 1 }) # :final == 1
                     .where(peer_review_reviews: { reviewer_id: user.id })
                     .count
 
-    [progress / (expected_reviews + 1), 1.0].min
+    [progress / (expected_reviews + 1.0), 1.0].min
   end
 
   def solvers


### PR DESCRIPTION
Ref: [Trello](https://trello.com/c/X72AQoth/311-si-hice-revisiones-pero-mi-tarea-esta-en-borrador-el-progreso-deberia-ser-cero)

El porcentaje estaba mostrando un 33%, por ejemplo, en caso de docentes que habían hecho una revisión pero no habían resuelto el problema. Sin resolución, no hay porcentaje (en general)