### PR TITLE
Small fixes, batch #1

### DIFF
--- a/app/controllers/lectures_controller.rb
+++ b/app/controllers/lectures_controller.rb
@@ -49,7 +49,7 @@ class LecturesController < ApplicationController
     end
   end
 
-  def summary
+  def overview
     authorize Lecture
     @lectures = Lecture.all
     @students = Course.current.memberships.includes({ user: :memberships }).student.collect(&:user)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,4 +12,8 @@ module ApplicationHelper
   def yes_no(bool_value)
     bool_value ? "Si" : "No"
   end
+
+  def checkmark(bool_value)
+    render "shared/checkmark", value: bool_value
+  end
 end

--- a/app/policies/lecture_policy.rb
+++ b/app/policies/lecture_policy.rb
@@ -2,7 +2,7 @@ class LecturePolicy < ApplicationPolicy
   def manage?
     user.teacher?
   end
-  def summary?
+  def overview?
     user.teacher?
   end
   def register?

--- a/app/views/layouts/_menu.html.erb
+++ b/app/views/layouts/_menu.html.erb
@@ -43,7 +43,7 @@
               </li>
               <li role="separator" class="divider"></li>
               <li>
-                <%= link_to "Resumen de Asistencia", summary_lectures_path %>
+                <%= link_to "Resumen de Asistencia", overview_lectures_path %>
               </li>
             <% end %>
           </ul>

--- a/app/views/lectures/overview.html.erb
+++ b/app/views/lectures/overview.html.erb
@@ -37,9 +37,7 @@
           <td>
             <% if lecture.required? %>
               <% present = student.present_at(lecture) %>
-              <label class="label label-<%= present ? 'success' : 'danger' %>">
-                <%= present ? '✔' : '✘' %>
-              </label>
+              <%= checkmark present %>
             <% else %>
               <label class="label label-default">
                 ✘

--- a/app/views/multiple_choices/questionnaires/overview.html.erb
+++ b/app/views/multiple_choices/questionnaires/overview.html.erb
@@ -57,7 +57,7 @@
             <td>
               <% correct = solution.correct_answer_for?(question) %>
               <label class="label label-<%= correct ? 'success' : 'danger' %>">
-                <%= correct ? '✔' : '✘' %>
+                <%= checkmark correct %>
               </label>
             </td>
           <% end %>

--- a/app/views/peer_review/reviews/new.html.erb
+++ b/app/views/peer_review/reviews/new.html.erb
@@ -5,7 +5,11 @@
 
 <%= raw @challenge.instructions %>
 
-<h2>Solución a revisar</h2>
+<% if current_user.teacher? %>
+  <h2>Solución de <%= @review.solution.author.full_name %></h2>
+<% else %>
+  <h2>Solución a revisar</h2>
+<% end %>
 <%= render partial: '/peer_review/solution_wording', locals: {source_code: @challenge.source_code?, wording: @review.solution.wording, language: @challenge.language } %>
 
 <% if @challenge.allows_attachment? %>

--- a/app/views/shared/_checkmark.html.erb
+++ b/app/views/shared/_checkmark.html.erb
@@ -1,0 +1,3 @@
+<label class="label label-<%= value ? 'success' : 'danger' %>">
+  <%= value ? '✔' : '✘' %>
+</label>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,7 +41,7 @@ Rails.application.routes.draw do
 
   resources :lectures, except: :destroy do
     collection do
-      get :summary
+      get :overview
     end
   end
 

--- a/lib/tasks/purge_challenges.rake
+++ b/lib/tasks/purge_challenges.rake
@@ -7,7 +7,7 @@ namespace :challenges do
       puts "Purging Challenges for Course #{course.name}"
 
       PeerReview::Challenge.all.each do |challenge|
-        if challenge.due? && challenge.needs_purge?
+        if (challenge.due? && challenge.needs_purge?) || !challenge.enabled?
           challenge.purge!
           puts "-> #{challenge.title} has been purged"
         end


### PR DESCRIPTION
Refs:

- [Trello](https://trello.com/c/9bloU3ih/338-se-deberian-purgar-los-desafios-cerrados-tmb-porque-algunos-se-cierran-y-no-se-vencen). El purger ahora borra datos de desafios cerrados, no necesariamente vencidos.
- [Trello](https://trello.com/c/qX6CUwCw/339-overview-es-summary). Se renombra `summary` para usar un lenguaje común -> `overview`
- [Trello](https://trello.com/c/JX3ZYRxJ/340-extraer-el-x-y-tilde-a-un-helper). Se extrae a un helper la funcionalidad de mostrar tildes o cruces en cuadros verdes o rojos, respectivamente.
- [Trello](https://trello.com/c/kzmlnw9S/352-cuando-docente-revisa-no-sabe-a-quien-le-esta-revisando-deberia-saber-pero-solo-por-ser-docente). Se muestra a los docentes a quién están corrigiendo. Es para evitar despistes, porque ahora pueden corregir a varios al mismo tiempo.