### PR TITLE
UI enhancements for page titles

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,5 @@
 class PagesController < ApplicationController
   def welcome
+    @title = "¡Bienvenido!"
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,9 @@
 module ApplicationHelper
+  def page_title(separator = " < ")
+    title = content_for(:title) || @title || "LoomDashboard"
+    [title, "LoomDashboard"].compact.join(separator)
+  end
+
   def entity_avatar(entity)
     if entity.avatar.attached?
       entity.avatar.variant(auto_orient: true)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,7 +1,7 @@
 module ApplicationHelper
-  def page_title(separator = " < ")
+  def page_title(separator = " | ")
     title = content_for(:title) || @title || "LoomDashboard"
-    [title, "LoomDashboard"].compact.join(separator)
+    [title, "LoomDashboard"].flatten.compact.join(separator)
   end
 
   def entity_avatar(entity)

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -8,10 +8,12 @@ module NavigationHelper
   end
 
   def nav_render
+    content_for(:title, ((nav_ensure.reverse.map { |nav| nav[:title] }).join(" < ")))
     render partial: "shared/navigation", locals: { nav: nav_ensure }
   end
 
   def nav_render4
+    content_for(:title, ((nav_ensure.reverse.map { |nav| nav[:title] }).join(" < ")))
     render partial: "shared/navigation4", locals: { nav: nav_ensure }
   end
 end

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -7,13 +7,20 @@ module NavigationHelper
     nav_ensure << { title: title, url: url }
   end
 
+  # Bootstrap 3
   def nav_render
-    content_for(:title, ((nav_ensure.reverse.map { |nav| nav[:title] }).join(" < ")))
+    set_title
     render partial: "shared/navigation", locals: { nav: nav_ensure }
   end
 
+  # Bootstrap 4
   def nav_render4
-    content_for(:title, ((nav_ensure.reverse.map { |nav| nav[:title] }).join(" < ")))
+    set_title
     render partial: "shared/navigation4", locals: { nav: nav_ensure }
   end
+
+  private
+    def set_title
+      @title = nav_ensure.reverse.map { |nav| nav[:title] }
+    end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>LoomDashboard</title>
+  <title><%== page_title %></title>
   <%= csrf_meta_tags %>
 
   <meta charset="utf-8">

--- a/app/views/layouts/application2.html.erb
+++ b/app/views/layouts/application2.html.erb
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-  <title>LoomDashboard</title>
+  <title><%== page_title %></title>
 
   <link rel="canonical" href="https://getbootstrap.com/docs/4.5/examples/grid/">
 

--- a/app/views/peer_review/challenges/show.html.erb
+++ b/app/views/peer_review/challenges/show.html.erb
@@ -2,12 +2,9 @@
 <% nav_add @challenge.title, '#' %>
 <%= nav_render4 %>
 
-
 <% unless @challenge.reviews.where(reviewer: current_user, status: :draft).empty? %>
-
   <%= render partial: 'shared/alert', locals: {alert_type: 'danger', title: '¡Cuidado!', dismissable: true,
      message: "Tenés una revisión no publicada. Tomate tu tiempo, pero publicala para que otro participantes puedan verla."} %>
-
 <% end %>
 
 <div id="wording" class="show">


### PR DESCRIPTION
Ref: [Trello](https://trello.com/c/HtmallUV/372-ui-mejorar-los-t%C3%ADtulos-de-las-p%C3%A1ginas)

Estamos mejorando los títulos de las páginas. Se utilizó la información de los breadcrumbs para construir los títulos. Se puede pisar definiendo la variable `@title`.